### PR TITLE
Fix the notification treatement at error reception

### DIFF
--- a/strophe.chatstates.js
+++ b/strophe.chatstates.js
@@ -28,6 +28,9 @@ Strophe.addConnectionPlugin('chatstates',
 
 	_notificationReceived: function(message)
 	{
+		if ($(message).find('error').length > 0)
+			return true;
+		
 		var composing = $(message).find('composing'),
 		paused = $(message).find('paused'),
 		active = $(message).find('active'),


### PR DESCRIPTION
When an error is sent back after a chatstate notification, nothing is now done in order to avoid to be notified about or own chatstate notification. Indeed, the error message has the chatstate notification from which it was raised.