### PR TITLE
Add missing chat states based on XEP-0085

### DIFF
--- a/strophe.chatstates.js
+++ b/strophe.chatstates.js
@@ -69,6 +69,16 @@ Strophe.addConnectionPlugin('chatstates',
 		this._sendNotification(jid, type, 'paused');
 	},
 
+	sendInactive: function(jid, type)
+	{
+		this._sendNotification(jid, type, 'inactive');
+	},
+
+	sendGone: function(jid, type)
+	{
+		this._sendNotification(jid, type, 'gone');
+	}
+
 	_sendNotification: function(jid, type, notification)
 	{
 		if (!type) type = 'chat';

--- a/strophe.chatstates.js
+++ b/strophe.chatstates.js
@@ -34,6 +34,8 @@ Strophe.addConnectionPlugin('chatstates',
 		var composing = $(message).find('composing'),
 		paused = $(message).find('paused'),
 		active = $(message).find('active'),
+		inactive = $(message).find('inactive'),
+		gone = $(message).find('gone'),
 		jid = $(message).attr('from');
 
 		if (composing.length > 0)
@@ -49,6 +51,16 @@ Strophe.addConnectionPlugin('chatstates',
 		if (active.length > 0)
 		{
 			$(document).trigger('active.chatstates', jid);
+		}
+
+		if (inactive.length > 0)
+		{
+			$(document).trigger('inactive.chatstates', jid);
+		}
+
+		if (gone.length > 0)
+		{
+			$(document).trigger('gone.chatstates', jid);
 		}
 
 		return true;

--- a/strophe.chatstates.js
+++ b/strophe.chatstates.js
@@ -89,7 +89,7 @@ Strophe.addConnectionPlugin('chatstates',
 	sendGone: function(jid, type)
 	{
 		this._sendNotification(jid, type, 'gone');
-	}
+	},
 
 	_sendNotification: function(jid, type, notification)
 	{


### PR DESCRIPTION
XEP-0085 (https://xmpp.org/extensions/xep-0085.html) supports the _gone_ and _inactive_ chat states. Added the additional functionality for receive/send of gone and inactive chat states.

fix #3 